### PR TITLE
修复两个错误

### DIFF
--- a/i7h.py
+++ b/i7h.py
@@ -9,5 +9,5 @@ def _f(r):
 
 
 def i18n(s: str) -> str:
-    s = re.sub(r'\w+', _f, s)
+    s = re.sub('[A-Za-z]+', _f, s)
     return s


### PR DESCRIPTION
1. 匹配非英文语段的错误，例如把“你好你好”转换为“你2好”
2. 匹配已经转换过的单词的错误，例如把“i18n”转换为“i2n”

该修复没有考虑带变音符号的拉丁字母等情况